### PR TITLE
Fix test runner

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 0.8.1
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
Looks like new Bun release (1.0) broke some APIs. The test runner GitHub Action was configured to use `latest` release instead of matching what the project uses.