### PR TITLE
Add delay after destroying test file system

### DIFF
--- a/src/testing/testFileSystem.ts
+++ b/src/testing/testFileSystem.ts
@@ -35,6 +35,7 @@ export async function createTestFileSystem(contents: FileSystemConstructionEntry
 
 export async function destroyTestFileSystem() {
   await deleteTestDirectory();
+  await new Promise(resolve => setTimeout(resolve, 150));
 }
 
 export function generateDirectoryEntryCollections(


### PR DESCRIPTION
This is so that file system has enough time to update.

This is a hack to temporarily mitigate #42 